### PR TITLE
Change to fork version togglv8 gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "togglv8"
+gem "togglv8", github: "ErebusBat/togglv8", branch: "fix-deprecation"
 # workaround for https://github.com/kanet77/togglv8/issues/17
 gem "awesome_print"
 gem "dotenv"


### PR DESCRIPTION
TogglのAPIのURLが変更されたため使用するGemをURLを差し替えたフォーク版のgemに変更したものです。